### PR TITLE
fix(export): create custom Excel cell format with Formatters.decimal

### DIFF
--- a/packages/common/src/enums/fieldType.enum.ts
+++ b/packages/common/src/enums/fieldType.enum.ts
@@ -32,10 +32,10 @@ export const FieldType = {
   /** Format: 'YYYY-MM-DD HH:mm:ss' <=> 2001-02-28 14:01:01 */
   dateTimeIso: 'dateTimeIso',
 
-  /** Format: 'YYYY-MM-DD h:mm:ss a' <=> 2001-02-28 11:01:01 pm */
+  /** Format: 'YYYY-MM-DD hh:mm:ss a' <=> 2001-02-28 11:01:01 pm */
   dateTimeIsoAmPm: 'dateTimeIsoAmPm',
 
-  /** Format: 'YYYY-MM-DD h:mm:ss A' <=> 2001-02-28 11:01:01 PM */
+  /** Format: 'YYYY-MM-DD hh:mm:ss A' <=> 2001-02-28 11:01:01 PM */
   dateTimeIsoAM_PM: 'dateTimeIsoAM_PM',
 
   /** Format: 'YYYY-MM-DD HH:mm' <=> 2001-02-28 14:01 */

--- a/packages/excel-export/package.json
+++ b/packages/excel-export/package.json
@@ -48,6 +48,7 @@
     "moment-mini": "^2.29.4"
   },
   "devDependencies": {
+    "@slickgrid-universal/event-pub-sub": "workspace:~",
     "cross-env": "^7.0.3",
     "npm-run-all2": "^6.0.4",
     "rimraf": "^3.0.2"

--- a/packages/excel-export/src/excelUtils.spec.ts
+++ b/packages/excel-export/src/excelUtils.spec.ts
@@ -1,0 +1,302 @@
+import { Column, ExcelStylesheet, FieldType, Formatters, GridOption, SlickGrid } from '@slickgrid-universal/common';
+import moment from 'moment-mini';
+
+import { useCellFormatByFieldType } from './excelUtils';
+
+const mockGridOptions = {
+  enableExcelExport: true,
+  enablePagination: true,
+  enableFiltering: true,
+} as GridOption;
+
+const gridStub = {
+  getColumnIndex: jest.fn(),
+  getOptions: () => mockGridOptions,
+  getColumns: jest.fn(),
+  getGrouping: jest.fn(),
+} as unknown as SlickGrid;
+
+const stylesheetStub = {
+  createFormat: jest.fn(),
+} as unknown as ExcelStylesheet;
+
+describe('excelUtils', () => {
+  let mockedFormatId = 135;
+  let createFormatSpy: any;
+
+  beforeEach(() => {
+    createFormatSpy = jest.spyOn(stylesheetStub, 'createFormat').mockReturnValue({ id: mockedFormatId });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('date formatter', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTime is provided', () => {
+      const column = { type: FieldType.dateTime } as Column;
+      const input = '2012-02-28 15:07:59';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'YYYY-MM-DD HH:mm:ss' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '2012-02-28 15:07:59' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeIso is provided', () => {
+      const column = { type: FieldType.dateTimeIso } as Column;
+      const input = '2012-02-28 15:07:59';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'YYYY-MM-DD HH:mm:ss' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '2012-02-28 15:07:59' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeShortIso is provided', () => {
+      const column = { type: FieldType.dateTimeShortIso } as Column;
+      const input = '2012-02-28 15:07:59';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'YYYY-MM-DD HH:mm' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '2012-02-28 15:07' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeIsoAmPm is provided', () => {
+      const column = { type: FieldType.dateTimeIsoAmPm } as Column;
+      const input = '2012-02-28 15:07:59';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'YYYY-MM-DD hh:mm:ss a' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '2012-02-28 03:07:59 pm' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeIsoAM_PM is provided', () => {
+      const column = { type: FieldType.dateTimeIsoAM_PM } as Column;
+      const input = '2012-02-28 15:07:59';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'YYYY-MM-DD hh:mm:ss A' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '2012-02-28 03:07:59 PM' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateEuro is provided', () => {
+      const column = { type: FieldType.dateEuro } as Column;
+      const input = '2012-02-28 15:07:59';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'DD/MM/YYYY' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '28/02/2012' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateEuroShort is provided', () => {
+      const column = { type: FieldType.dateEuroShort } as Column;
+      const input = '2012-02-28 15:07:59';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'D/M/YY' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '28/2/12' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeEuro is provided', () => {
+      const column = { type: FieldType.dateTimeEuro } as Column;
+      const input = '2012-02-28 15:07:59';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'DD/MM/YYYY HH:mm:ss' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '28/02/2012 15:07:59' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeShortEuro is provided', () => {
+      const column = { type: FieldType.dateTimeShortEuro } as Column;
+      const input = '2012-02-28 15:07:59';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'DD/MM/YYYY HH:mm' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '28/02/2012 15:07' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeEuroAmPm is provided', () => {
+      const column = { type: FieldType.dateTimeEuroAmPm } as Column;
+      const input = '2012-02-28 15:07:59';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'DD/MM/YYYY hh:mm:ss a' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '28/02/2012 03:07:59 pm' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeEuroAM_PM is provided', () => {
+      const column = { type: FieldType.dateTimeEuroAM_PM } as Column;
+      const input = '2012-02-28 15:07:59';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'DD/MM/YYYY hh:mm:ss A' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '28/02/2012 03:07:59 PM' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeEuroShort is provided', () => {
+      const column = { type: FieldType.dateTimeEuroShort } as Column;
+      const input = '2012-02-28 15:07:46';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'D/M/YY H:m:s' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '28/2/12 15:7:46' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeEuroShortAmPm is provided', () => {
+      const column = { type: FieldType.dateTimeEuroShortAmPm } as Column;
+      const input = '2012-02-28 15:07:46';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'D/M/YY h:m:s a' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '28/2/12 3:7:46 pm' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateUs is provided', () => {
+      const column = { type: FieldType.dateUs } as Column;
+      const input = new Date('2012-02-28 15:07:59');
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'MM/DD/YYYY' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '02/28/2012' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateUsShort is provided', () => {
+      const column = { type: FieldType.dateUsShort } as Column;
+      const input = new Date('2012-02-28 15:07:59');
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'M/D/YY' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '2/28/12' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeUs is provided', () => {
+      const column = { type: FieldType.dateTimeUs } as Column;
+      const input = new Date('2012-02-28 15:07:59');
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'MM/DD/YYYY HH:mm:ss' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '02/28/2012 15:07:59' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeShortUs is provided', () => {
+      const column = { type: FieldType.dateTimeShortUs } as Column;
+      const input = new Date('2012-02-28 15:07:59');
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'MM/DD/YYYY HH:mm' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '02/28/2012 15:07' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeUsAmPm is provided', () => {
+      const column = { type: FieldType.dateTimeUsAmPm } as Column;
+      const input = new Date('2012-02-28 15:07:59');
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'MM/DD/YYYY hh:mm:ss a' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '02/28/2012 03:07:59 pm' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeUsAM_PM is provided', () => {
+      const column = { type: FieldType.dateTimeUsAM_PM } as Column;
+      const input = new Date('2012-02-28 15:07:59');
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'MM/DD/YYYY hh:mm:ss A' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '02/28/2012 03:07:59 PM' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeUsShort is provided', () => {
+      const column = { type: FieldType.dateTimeUsShort } as Column;
+      const input = new Date('2012-02-28 15:07:59');
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'M/D/YY H:m:s' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '2/28/12 15:7:59' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateTimeUsShortAmPm is provided', () => {
+      const column = { type: FieldType.dateTimeUsShortAmPm } as Column;
+      const input = new Date('2012-02-28 15:07:59');
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'M/D/YY h:m:s a' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '2/28/12 3:7:59 pm' });
+    });
+
+    xit('should call createFormat with a format of an ISO date when FieldType.dateUtc is provided', () => {
+      const column = { type: FieldType.dateUtc } as Column;
+      const input = moment('2013-05-23T17:55:00.325').utcOffset(420); // timezone that is +7 UTC hours
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'YYYY-MM-DDTHH:mm:ss.SSSZ' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '2013-05-24T04:55:00.325+07:00' });
+    });
+
+    it('should call createFormat with a format of an ISO date when FieldType.dateIso is provided', () => {
+      const column = { type: FieldType.dateIso } as Column;
+      const input = '2012-02-28 15:07:46';
+      const output = useCellFormatByFieldType(stylesheetStub, {}, input, column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: 'YYYY-MM-DD' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: '2012-02-28' });
+    });
+  });
+
+  describe('decimal formatter', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call createFormat with a format of "###0.00" when a number is provided without any specific formatter options', () => {
+      const column = { type: FieldType.number, formatter: Formatters.decimal } as Column;
+      const output = useCellFormatByFieldType(stylesheetStub, {}, '12', column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: '###0.00' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: 12 });
+    });
+
+    it('should call createFormat with a format of "###0.0##" when a number is provided minDecimal & maxDecimal formatter options', () => {
+      const column = { type: FieldType.number, formatter: Formatters.decimal, params: { minDecimal: 1, maxDecimal: 3 } } as Column;
+      const output = useCellFormatByFieldType(stylesheetStub, {}, '12', column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: '###0.0##' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: 12 });
+    });
+
+    it('should call createFormat with a format of "€ ###0.00" when a number is provided minDecimal & maxDecimal formatter options', () => {
+      const column = { type: FieldType.number, formatter: Formatters.decimal, params: { numberPrefix: '€ ' } } as Column;
+      const output = useCellFormatByFieldType(stylesheetStub, {}, '12', column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: '€ ###0.00' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: 12 });
+    });
+
+    it('should call createFormat with a format of "#,##0.00" when a number is provided minDecimal & maxDecimal formatter options', () => {
+      const column = { type: FieldType.number, formatter: Formatters.decimal, params: { thousandSeparator: ',' } } as Column;
+      const output = useCellFormatByFieldType(stylesheetStub, {}, '12', column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: '#,##0.00' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: 12 });
+    });
+
+    it('should call createFormat with a format of "# ##0.00 USD" when a number is provided thousandSeparator & numberSuffix formatter options', () => {
+      const column = { type: FieldType.number, formatter: Formatters.decimal, params: { thousandSeparator: ' ', numberSuffix: ' USD' } } as Column;
+      const output = useCellFormatByFieldType(stylesheetStub, {}, '12', column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: '# ##0.00 USD' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: 12 });
+    });
+
+    it('should call createFormat with a format of "#,##0.00 USD;(#,##0.00 USD)" when a number is provided displayNegativeNumberWithParentheses, thousandSeparator & numberSuffix formatter options', () => {
+      const column = { type: FieldType.number, formatter: Formatters.decimal, params: { displayNegativeNumberWithParentheses: true, thousandSeparator: ',', numberSuffix: ' USD' } } as Column;
+      const output = useCellFormatByFieldType(stylesheetStub, {}, '12', column, gridStub);
+
+      expect(createFormatSpy).toHaveBeenCalledWith({ format: '#,##0.00 USD;(#,##0.00 USD)' });
+      expect(output).toEqual({ metadata: { style: mockedFormatId }, value: 12 });
+    });
+  });
+
+});

--- a/packages/excel-export/src/excelUtils.ts
+++ b/packages/excel-export/src/excelUtils.ts
@@ -1,0 +1,98 @@
+import { Column, ExcelCellFormat, ExcelStylesheet, FieldType, Formatters, getValueFromParamsOrFormatterOptions, mapMomentDateFormatWithFieldType, SlickGrid } from '@slickgrid-universal/common';
+import * as moment_ from 'moment-mini';
+const moment = (moment_ as any)['default'] || moment_; // patch to fix rollup "moment has no default export" issue, document here https://github.com/rollup/rollup/issues/670
+
+/** use different Excel Stylesheet Format as per the Field Type */
+export function useCellFormatByFieldType(stylesheet: ExcelStylesheet, stylesheetFormatters: any, data: string | Date | moment_.Moment, columnDef: Column, grid: SlickGrid): ExcelCellFormat | string {
+  const fieldType = columnDef.outputType || columnDef.type || FieldType.string;
+  let outputData: ExcelCellFormat | string | Date | moment_.Moment = data;
+
+  switch (fieldType) {
+    case FieldType.dateTime:
+    case FieldType.dateTimeIso:
+    case FieldType.dateTimeShortIso:
+    case FieldType.dateTimeIsoAmPm:
+    case FieldType.dateTimeIsoAM_PM:
+    case FieldType.dateEuro:
+    case FieldType.dateEuroShort:
+    case FieldType.dateTimeEuro:
+    case FieldType.dateTimeShortEuro:
+    case FieldType.dateTimeEuroAmPm:
+    case FieldType.dateTimeEuroAM_PM:
+    case FieldType.dateTimeEuroShort:
+    case FieldType.dateTimeEuroShortAmPm:
+    case FieldType.dateUs:
+    case FieldType.dateUsShort:
+    case FieldType.dateTimeUs:
+    case FieldType.dateTimeShortUs:
+    case FieldType.dateTimeUsAmPm:
+    case FieldType.dateTimeUsAM_PM:
+    case FieldType.dateTimeUsShort:
+    case FieldType.dateTimeUsShortAmPm:
+    case FieldType.dateUtc:
+    case FieldType.date:
+    case FieldType.dateIso:
+      outputData = data;
+      if (data) {
+        const defaultDateFormat = mapMomentDateFormatWithFieldType(fieldType);
+        const isDateValid = moment(data as string, defaultDateFormat, false).isValid();
+        const outputDate = (data && isDateValid) ? moment(data as string).format(defaultDateFormat) : data;
+        if (!stylesheetFormatters.hasOwnProperty(fieldType)) {
+          stylesheetFormatters[fieldType] = stylesheet.createFormat({ format: defaultDateFormat });
+        }
+        outputData = { value: outputDate, metadata: { style: stylesheetFormatters[fieldType].id } };
+      }
+      break;
+    case FieldType.number:
+      const num = parseFloat(data as string);
+      const val = isNaN(num) ? null : +num;
+      let stylesheetFormatter: object & { id: string; };
+
+      switch (columnDef.formatter) {
+        case Formatters.decimal:
+        case Formatters.dollar:
+        case Formatters.dollarColored:
+        case Formatters.dollarColoredBold:
+          stylesheetFormatter = createOrGetStylesheetFormatter(stylesheet, stylesheetFormatters, columnDef, grid);
+          break;
+        default:
+          stylesheetFormatter = stylesheetFormatters.numberFormatter;
+          break;
+      }
+      outputData = { value: val, metadata: { style: stylesheetFormatter.id } };
+      break;
+    default:
+      outputData = data;
+  }
+  return outputData as string;
+}
+
+function createOrGetStylesheetFormatter(stylesheet: ExcelStylesheet, stylesheetFormatters: any, columnDef: Column, grid: SlickGrid) {
+  const minDecimal = getValueFromParamsOrFormatterOptions('minDecimal', columnDef, grid, 2);
+  const maxDecimal = getValueFromParamsOrFormatterOptions('maxDecimal', columnDef, grid, 2);
+  const decimalSeparator = getValueFromParamsOrFormatterOptions('decimalSeparator', columnDef, grid, '.');
+  const thousandSeparator = getValueFromParamsOrFormatterOptions('thousandSeparator', columnDef, grid, '');
+  const numberPrefix = getValueFromParamsOrFormatterOptions('numberPrefix', columnDef, grid, '');
+  const numberSuffix = getValueFromParamsOrFormatterOptions('numberSuffix', columnDef, grid, '');
+  const displayNegativeNumberWithParentheses = getValueFromParamsOrFormatterOptions('displayNegativeNumberWithParentheses', columnDef, grid, false);
+  const numberFormat = `${numberPrefix}#${thousandSeparator}##0${decimalSeparator}${excelNumberFormatPadding(minDecimal, maxDecimal)}${numberSuffix}`;
+  const format = displayNegativeNumberWithParentheses ? `${numberFormat};(${numberFormat})` : numberFormat;
+
+  if (!stylesheetFormatters.hasOwnProperty(format)) {
+    stylesheetFormatters[format] = stylesheet.createFormat({ format }); // save new formatter with its format as a prop key
+  }
+  return stylesheetFormatters[format];
+}
+
+/** Get number format for a number cell, for example { minDecimal: 2, maxDecimal: 5 } will return "00###" */
+function excelNumberFormatPadding(minDecimal: number, maxDecimal: number) {
+  return textPadding('0', minDecimal) + textPadding('#', maxDecimal - minDecimal);
+}
+
+function textPadding(numberStr: string, count: number): string {
+  let output = '';
+  for (let i = 0; i < count; i++) {
+    output += numberStr;
+  }
+  return output;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,7 @@ importers:
   packages/excel-export:
     specifiers:
       '@slickgrid-universal/common': workspace:~
+      '@slickgrid-universal/event-pub-sub': workspace:~
       '@slickgrid-universal/utils': workspace:~
       cross-env: ^7.0.3
       excel-builder-webpacker: ^2.1.7
@@ -305,6 +306,7 @@ importers:
       excel-builder-webpacker: 2.1.7
       moment-mini: 2.29.4
     devDependencies:
+      '@slickgrid-universal/event-pub-sub': link:../event-pub-sub
       cross-env: 7.0.3
       npm-run-all2: 6.0.4
       rimraf: 3.0.2


### PR DESCRIPTION
- when using `Formatters.decimal`, the Excel export should automatically create custom format depending on decimal formatter options provided
- extending PR #843